### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+atlalign
+atlannot
+atldld
+atlinter


### PR DESCRIPTION
This file is not really supposed to be installed via `pip install -r requirements.txt` (but it can), but rather to add "Deep-Atlas" into the dependency graph of the 4 child repositories.

The advantage would be that they all will link back to this repository via a "Used By" icon on the right-hand side of [`bluesearch`](https://github.com/BlueBrain/Search) that links back to [`Search-Graph-Examples`](https://github.com/BlueBrain/Search-Graph-Examples):
![github-used-by](https://user-images.githubusercontent.com/8017698/140958510-f06b9f2c-9014-410f-aa55-1795714eb235.png)
