### PR TITLE
Add group id option to Dockerfile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ docker build -f docker/Dockerfile -t deep-atlas-pipeline \
 
 To specify the user to use when running the container, use the following command:
 ```bash
-docker run --rm -it -u <userid>  deep-atlas-pipeline
+docker run --rm -it -u <username>  deep-atlas-pipeline
 ```
 
 ## Singularity for BB5

--- a/README.md
+++ b/README.md
@@ -84,34 +84,41 @@ We provide a docker file that allows you to run the `pipeline` on a docker conta
 To build the docker image run the following command:
 
 ```bash
-docker build 
--f docker/Dockerfile
--t deep-atlas-pipeline
-.
+docker build -f docker/Dockerfile -t deep-atlas-pipeline .
 ```
-By default, the user is `guest` but if one wants to configure a specific user, 
-one needs to first uncomment the line and add the info about the users.
-The list of users has a comma separated list of users with the format `<username>/<userid>`.
-```bash
-ENV DEAL_USER_IDS="$(whoami)/$(id -u)"
-```
-or one can define the environment variable and use add this info 
-to the CLI command of `docker build`
-```bash
-export DEAL_USER_IDS="$(whoami)/$(id -u)"
-docker build \
--f docker/Dockerfile \
--t deep-atlas-pipeline \
---build-arg DEAL_USER_IDS \
-.
-```
-
 To run the container use the following command:
 ```bash
 docker run --rm -it deep-atlas-pipeline
 ```
+### Specify user and group ids
 
-### Singularity for BB5
+By default, the user within the docker container is `guest`, its id is 1000, and its group is 999. \
+Files created by this user within the container might not be accessible to the user running 
+the container, if their ids do not match. \
+If one wants to configure a specific user, one needs to adapt the `docker/Dockerfile` file, 
+changing the following lines with the users .
+```bash
+ARG DEAL_USER_IDS
+ARG DEAL_GROUP_ID=${DEAL_GROUP_ID:-999}
+```
+The list of users has a comma separated list of users with the format `<username>/<userid>`. \
+Only one group id should be provided. The default user group is therefore recommended.
+
+Alternatively, one can define the environment variable and add this info 
+to the CLI command of `docker build`
+```bash
+export DEAL_USER_IDS="$(whoami)/$(id -u)"
+export DEAL_GROUP_ID=$(id -g)
+docker build -f docker/Dockerfile -t deep-atlas-pipeline \
+--build-arg DEAL_USER_IDS --build-arg DEAL_GROUP_ID .
+```
+
+To specify the user to use when running the container, use the following command:
+```bash
+docker run --rm -it -u <userid>  deep-atlas-pipeline
+```
+
+## Singularity for BB5
 Docker is not supported in BB5 and [singularity](https://docs.sylabs.io/guides/3.5/user-guide/introduction.html) will be used instead.
 1) ssh into BB5. 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,17 +2,16 @@
 # for example "python:3.7" can be used.
 FROM nvidia/cuda:10.2-devel-ubuntu18.04
 
-# ENVs are visible both at image build time and container run time.
-# We want the http proxys to be visible in both cases and therefore
-# set them equal to the values of the ARGs.
-ENV http_proxy=http://bbpproxy.epfl.ch:80
-ENV https_proxy=http://bbpproxy.epfl.ch:80
-ENV HTTP_PROXY=http://bbpproxy.epfl.ch:80
-ENV HTTPS_PROXY=http://bbpproxy.epfl.ch:80
-#ENV DEAL_USER_IDS=
+# By default, only the user guest/1000 with group 1000 will be created.
+# Set the lines below with your users info
+# e.g.: ARG DEAL_USER_IDS="<username1>/<userid1>,<username2>/<userid2>"
+ARG DEAL_USER_IDS
+# e.g.: ARG DEAL_GROUP_ID=<groupid>
+ARG DEAL_GROUP_ID=${DEAL_GROUP_ID:-999}
 
-RUN test -n "$DEAL_USER_IDS" || echo "WARNING: variable DEAL_USER_IDS was not set, creating only default user 'guest/1000' !"
-
+RUN if [ ! -z $DEAL_USER_IDS ]; then \
+echo "The following user(s) will be added to the container: \
+$DEAL_USER_IDS, with group: docker/$DEAL_GROUP_ID"; fi
 
 # Debian's default LANG=C breaks python3.
 # See commends in the official python docker file:
@@ -46,12 +45,11 @@ update-alternatives --install /usr/local/bin/python python /usr/bin/python3.7 0
 # Install requirements
 COPY requirements.txt /tmp
 RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
-ARG MY_USER_ID
+
+RUN groupadd -g $DEAL_GROUP_ID docker
+ENV USER_IDS=$DEAL_USER_IDS",guest/1000"
 COPY docker/utils.sh /tmp
-RUN \
-. /tmp/utils.sh && \
-groupadd -g 999 docker && \
-create_users "${DEAL_USER_IDS},guest/1000" "docker"
+RUN bash -c '. /tmp/utils.sh; create_users "${USER_IDS}" "docker"'
 
 # Entry point
 EXPOSE 8888

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,12 @@
 # for example "python:3.7" can be used.
 FROM nvidia/cuda:10.2-devel-ubuntu18.04
 
+# Proxys only for EPFL usages.
+#ENV http_proxy=http://bbpproxy.epfl.ch:80
+#ENV https_proxy=http://bbpproxy.epfl.ch:80
+#ENV HTTP_PROXY=http://bbpproxy.epfl.ch:80
+#ENV HTTPS_PROXY=http://bbpproxy.epfl.ch:80
+
 # By default, only the user guest/1000 with group 1000 will be created.
 # Set the lines below with your users info
 # e.g.: ARG DEAL_USER_IDS="<username1>/<userid1>,<username2>/<userid2>"

--- a/docker/utils.sh
+++ b/docker/utils.sh
@@ -1,5 +1,47 @@
 #!/bin/bash
 
+add_aliases() {
+  # Write some useful aliases to "~/.bash_aliases"
+  echo "alias ll='ls -lah'\n" >> "$HOME/.bash_aliases"
+}
+
+improve_prompt() {
+  # Different prompt colours for root and non-root users
+  if [ -z "$USER" ]
+  then
+    local USER_MODE="03"
+    local USER_COLOR="36"
+  else
+    local USER_MODE="01"
+    local USER_COLOR="33"
+  fi
+
+  # Define parts of PS1
+  local USER_STR="\[\e[${USER_MODE};${USER_COLOR}m\]\u\[\e[00m\]"
+  local WORKDIR_STR="\[\e[01;34m\]\w\[\e[00m\]"
+  local GIT_STR="\[\e[0;35m\]\$(parse_git_branch)\[\e[00m\]"
+
+  # Write configuration to ~/.bashrc
+  echo "
+function parse_git_branch {
+  local ref
+  ref=\$(command git symbolic-ref HEAD 2> /dev/null) || return 0
+  echo \"‹\${ref#refs/heads/}› \"
+}
+PS1='${USER_STR} :: ${WORKDIR_STR} ${GIT_STR}$ '
+" >> "$HOME/.bashrc"
+}
+
+configure_user() {
+  # If this directory doesn't exist it won't be included in the $PATH
+  # and python entrypoints for user-installed packages won't work
+  mkdir -p "$HOME/.local/bin"
+
+  # miscellaneous tweaks and settings
+  add_aliases
+  improve_prompt
+}
+
 create_users() {
   local USERS="$1"
   local GROUP="$2"
@@ -19,7 +61,7 @@ create_users() {
     user_ids+=($user_id)
     user_home="/home/${user_name}"
     useradd --create-home --uid "$user_id" --gid "$GROUP" --home-dir "$user_home" "$user_name"
-    su "$user_name" -c "$(declare -f configure_user add_aliases improve_prompt configure_jupyter) &&  configure_user"
+    su "$user_name" -c "$(declare -f configure_user add_aliases improve_prompt) &&  configure_user"
     echo "Added user ${user_name} with ID ${user_id}"
   done
 }

--- a/docker/utils.sh
+++ b/docker/utils.sh
@@ -1,7 +1,9 @@
+#!/bin/bash
+
 create_users() {
   local USERS="$1"
   local GROUP="$2"
-
+  local user_ids=()
   for x in $(echo "$USERS" | tr "," "\n")
   do
     # skip empty user entries
@@ -13,6 +15,8 @@ create_users() {
     # Create and configure user
     user_name="${x%/*}"
     user_id="${x#*/}"
+    while [[ " ${user_ids[*]} " == *" ${user_id} "* ]]; do user_id=$(($user_id+1)); done
+    user_ids+=($user_id)
     user_home="/home/${user_name}"
     useradd --create-home --uid "$user_id" --gid "$GROUP" --home-dir "$user_home" "$user_name"
     su "$user_name" -c "$(declare -f configure_user add_aliases improve_prompt configure_jupyter) &&  configure_user"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/BlueBrain/atlas-annotation@v0.1.3
 atldld
-git+https://github.com/BlueBrain/atlas-interpolation@v0.2.4#egg=atlinter[optical]
+git+https://github.com/BlueBrain/atlas-interpolation@v0.2.5#egg=atlinter[optical]
 numpy
 pillow
 pynrrd


### PR DESCRIPTION
What is new:
- Add group_id option to Dockerfile
- Remove EPFL proxys for BB5
- Update README.md
- Check provided user ids to prevent similar ones

Still to address:
- The line 22 in `utils.sh` seems to be doing nothing since the functions in `declare` do not exist: 
```
su "$user_name" -c "$(declare -f configure_user add_aliases improve_prompt configure_jupyter) &&  configure_user" 
```